### PR TITLE
ForeignKey Creates Joins Automagically

### DIFF
--- a/src/Db/Compile/DdlCompiler.php
+++ b/src/Db/Compile/DdlCompiler.php
@@ -41,7 +41,7 @@ abstract class DdlCompiler {
                 else
                     $constraints[] = $extras;
             }
-            $columns[] = sprintf("%s %s", $this->quote($name), $coldef);
+            $columns[] = sprintf("%s %s", $this->quote($F->column ?? $name), $coldef);
         }
         return new Statement(sprintf('CREATE TABLE %s (%s%s)',
             $this->quote($meta['table']),

--- a/src/Db/Fields/BaseField.php
+++ b/src/Db/Fields/BaseField.php
@@ -12,6 +12,7 @@ abstract class BaseField {
         'nullable' => true,
         'default' => null,
         'pk' => false,
+        'column' => null,
     );
     static $transforms;
 

--- a/src/Db/Fields/BaseField.php
+++ b/src/Db/Fields/BaseField.php
@@ -82,6 +82,25 @@ abstract class BaseField {
         return isset($this->options[$option]);
     }
 
+    function __set($option, $value) {
+        if (!array_key_exists($option, $this->options))
+            throw new \Exception(sprintf(
+                "%s: Field option does not exist", $option));
+        $this->options[$option] = $value;
+    }
+
+    /**
+     * Allow fields to interact with the schema creation process. Useful for
+     * more magical fields like ForeignKey which influence the schema.
+     *
+     * Parameters:
+     * $name - name of the field
+     * $builder - SchemaBuilder instance used to describe the schema
+     */
+    function addToSchema($name, Model\SchemaBuilder $builder) {
+        // abstract -- pass
+    }
+
     /**
      * Cooperate in a CREATE TABLE statement for SqlCompilers
      */

--- a/src/Db/Fields/ForeignKey.php
+++ b/src/Db/Fields/ForeignKey.php
@@ -77,6 +77,10 @@ extends BaseField {
         return $this->ffield->from_export($value);
     }
 
+    function getTransform($name, $lhs) {
+        return $this->ffield->getTransform($name, $lhs);
+    }
+
     function addToSchema($name, Model\SchemaBuilder $builder) {
         $fmodel = $this->fmodel;
         $ffield = $this->ffield;

--- a/src/Db/Fields/ForeignKey.php
+++ b/src/Db/Fields/ForeignKey.php
@@ -142,7 +142,7 @@ extends BaseField {
                 'constraint' => [
                     $this->ffield_name => [$lmeta->model, $name]
                 ],
-                'list' => true,
+                'list' => !$this instanceof OneToOneField,
                 'null' => true,
             ]);
         }

--- a/src/Db/Fields/ForeignKey.php
+++ b/src/Db/Fields/ForeignKey.php
@@ -2,14 +2,32 @@
 namespace Phlite\Db\Fields;
 
 use Phlite\Db;
+use Phlite\Db\Backend;
 use Phlite\Db\Exception;
 use Phlite\Db\Model;
 
+/**
+ * Adds a REFERENCES clause to the create and alter SQL for database platforms
+ * which support foreign keys in their schema. When used on a local field, the
+ * actual type of the field
+ */
 class ForeignKey
-extends IntegerField {
+extends BaseField {
+    protected $ffield_name;
     protected $ffield;
     protected $fmodel;
     protected $fmeta;
+
+    static $defaults = [
+        // local to foreign field mapping. Can be multiple items for composite
+        // keys (not yet supported).
+        'key' => null,
+        // Create or use a local join to refer to the foreign model
+        'join' => null,
+        // Name of a join to add to the foreign model. Will become a list of
+        // local instances which refer to the foreign instance
+        'reverse_name' => null,
+    ];
 
     function __construct($field, $options=array()) {
         parent::__construct($options);
@@ -17,7 +35,7 @@ extends IntegerField {
         // Lookup the field and import the settings
         if (!is_array($field))
             $field = explode('.', $field);
-        @list($fmodel, $this->ffield) = $field;
+        @list($fmodel, $ffield) = $field;
         if (!class_exists($fmodel)) {
             throw new Exception\OrmError(sprintf('ForeignKey: %s: No such model', $fmodel));
         }
@@ -27,33 +45,139 @@ extends IntegerField {
 
         // Allow use of model class name and assume link to primary key
         // field. This also assumes that there is only one field in the pk
-        if (!$this->ffield && is_subclass_of($fmodel, Model\ModelBase::class)) {
+        if (!$ffield && is_subclass_of($fmodel, Model\ModelBase::class)) {
             $pk = $this->fmeta['pk'];
             if (count($pk) > 1) {
-                throw new Exception\OrmError('Cannot link to model with composite primray key without specifying fields.');
+                throw new Exception\OrmError('Cannot link to model with composite primary key without specifying fields.');
             }
-            $this->ffield = $pk[0];
+            $ffield = $pk[0];
         }
 
-        if (!$this->ffield)
+        if (!$ffield)
             throw new Exception\OrmError('Unable to determine foreign key field');
+
+        $this->ffield_name = $ffield;
+        $this->ffield = $this->getForeignFieldType($ffield);
+    }
+
+    // Delegate conversions to foreign field type
+    function to_database($value, Backend $backend) {
+        return $this->ffield->to_database($value, $backend);
+    }
+
+    function to_php($value, Backend $backend) {
+        return $this->ffield->to_php($value, $backend);
+    }
+
+    function to_export($value) {
+        return $this->ffield->to_export($value);
+    }
+
+    function from_export($value) {
+        return $this->ffield->from_export($value);
+    }
+
+    function addToSchema($name, Model\SchemaBuilder $builder) {
+        $fmodel = $this->fmodel;
+        $ffield = $this->ffield;
+        $fmeta = $fmodel::getMeta();
+        $lmeta = $builder->getModelMeta();
+        $pk = $fmeta['pk'];
+
+        // Figure out the local key (the REFERENCES part of the foreign key).
+        // Also, figure out what the join should be called and if one should
+        // be added to the local model.
+        if (isset($this->key)) {
+            $key = $this->key;
+            $join = $name;
+        }
+        elseif (isset($this->column)) {
+            // $local is the join and $column is the field name
+            $key = [$this->column = [$fmodel, $pk[0]]];
+            $join = $name;
+        }
+        elseif (isset($this->join)) {
+            if ($this->join != $name) {
+                // In this case, the $name is the column and join is the auto
+                // join to be created
+                $key = [$name => [$fmodel, $pk[0]]];
+                $join = $this->join;
+            }
+            elseif (!isset($lmeta['joins'][$this->join])) {
+                throw new Exception\ModelConfigurationError(sprintf(
+                    '%s: Field specifies `join` %s, but does not exist. Specify '
+                   .'`column` or `key` if join should be automatically created.',
+                    $name, $builder->meta->model));
+            }
+            else {
+                $key = $lmeta['joins'][$this->join]['constraint'];
+                $join = $this->join;
+            }
+        }
+        else {
+            throw new Exception\ModelConfigurationError(sprintf(
+                '%s: ForeignKey must specify either `join` or `key` or `column` in '
+               .'order to identify both the relationship and column names.',
+                $name));
+        }
+
+        // Save the inspected key
+        $this->key = $key;
+
+        // If a join is referenced but doesn't exist locally, add it to 
+        // the model
+        if (!isset($this->join) || !isset($lmeta['joins'][$join])) {
+            $lmeta->addJoin($join, [
+                'constraint' => $key
+            ]);
+        }
+
+        // If `reverse_name` is set, then add a join to the foreign model
+        if (isset($this->reverse_name)) {
+            $fmeta->addJoin($this->reverse_name, [
+                'constraint' => [
+                    $this->ffield_name => [$lmeta->model, $name]
+                ],
+                'list' => true,
+                'null' => true,
+            ]);
+        }
+    }
+
+    function getForeignModel() {
+        return $this->fmodel;
+    }
+
+    function getForeignFieldName() {
+        return $this->ffield_name;
+    }
+
+    function getForeignField() {
+        return $this->ffield;
+    }
+
+    function getForeignFieldType($field) {
+        $ffield = $this->fmeta->getField($field);
+        $fclass = get_class($ffield);
+        # Auto foreign keys should not be primary
+        $options = $this->options + $ffield->options;
+        $options['pk'] = false;
+        if ($fclass == AutoIdField::class)
+            $fclass = IntegerField::class;
+        return new $fclass($options);
     }
 
     function getCreateSql($name, $compiler) {
         // Try and match the database field type exactly
-        $ffield = $this->fmeta->getField($this->ffield);
 
         // Get the create sql for the referenced field. But drop the primary key
         // part as it is a foreign key in this table. Also, auto-id fields should
         // be changed to simple integer field.
-        $fclass = get_class($ffield);
-        if ($fclass == AutoIdField::class)
-            $fclass = IntegerField::class;
-        $ffield = new $fclass($this->options + $ffield->options);
+        $simple_key = current($this->key);
         return sprintf('%s REFERENCES %s (%s)',
-                $ffield->getCreateSql($name, $compiler),
-                $compiler->quote($this->fmeta['table']),
-                $compiler->quote($this->ffield)
+                $this->ffield->getCreateSql($name, $compiler),
+                $compiler->quote($this->fmeta['table']), # XXX: Use $key[0]?
+                $compiler->quote($simple_key[1]) # XXX: Assumes simple key
             );
     }
 }

--- a/src/Db/Fields/OneToOneField.php
+++ b/src/Db/Fields/OneToOneField.php
@@ -1,0 +1,11 @@
+<?php
+namespace Phlite\Db\Fields;
+
+/**
+ * Same as a standard ForeignKey, except that the reverse relationship is
+ * automatically *not* a list. One to one fields are often used as a form
+ * of inheritance or extension in SQL databases.
+ */
+class OneToOneField
+extends ForeignKey {
+}

--- a/src/Db/Model/ModelMeta.php
+++ b/src/Db/Model/ModelMeta.php
@@ -205,18 +205,20 @@ implements \ArrayAccess {
     function buildJoin($j) {
         $constraint = array();
         if (isset($j['reverse'])) {
-            list($fmodel, $key) = explode('.', $j['reverse']);
+            list($fmodel, $key) = is_string($j['reverse'])
+                ? explode('.', $j['reverse']) : $j['reverse'];
             if (strpos($fmodel, '\\') === false) {
                 // Transfer namespace from this model
                 $fmodel = $this->meta['namespace']. '\\' . $fmodel;
             }
             // NOTE: It's ok if the forein meta data is not yet inspected.
             $info = $fmodel::$meta['joins'][$key];
-            if (!is_array($info['constraint']))
+            if (!is_array($info['constraint'])) {
                 throw new Exception\ModelConfigurationError(sprintf(
                     // `reverse` here is the reverse of an ORM relationship
-                    '%s: Reverse does not specify any constraints'),
-                    $j['reverse']);
+                    '%s: Reverse does not specify any constraints',
+                    $j['reverse']));
+            }
             foreach ($info['constraint'] as $foreign => $local) {
                 list($L,$field) = is_array($local) ? $local : explode('.', $local);
                 $constraint[$field ?: $L] = array($fmodel, $foreign);
@@ -371,7 +373,7 @@ implements \ArrayAccess {
      * Convenience method to return the schema defined for the model.
      */
     function getSchema() {
-        $builder = new SchemaBuilder();
+        $builder = new SchemaBuilder($this);
         $this->model::buildSchema($builder);
         return $builder->getFields();
     }

--- a/src/Db/Model/SchemaBuilder.php
+++ b/src/Db/Model/SchemaBuilder.php
@@ -1,11 +1,17 @@
 <?php
 namespace Phlite\Db\Model;
 
+use Phlite\Db\Exception;
 use Phlite\Db\Fields;
 
 class SchemaBuilder {
+    protected $meta;
     protected $fields = array();
     protected $constraints = array();
+
+    function __construct(ModelMeta $modelMeta) {
+        $this->meta = $modelMeta;
+    }
 
     function addFields($fields) {
         foreach ($fields as $name=>$F)
@@ -14,6 +20,7 @@ class SchemaBuilder {
 
     function addField($name, Fields\BaseField $field) {
         $this->fields[$name] = $field;
+        $field->addToSchema($name, $this);
     }
 
     function addConstraints($constraints) {
@@ -36,5 +43,9 @@ class SchemaBuilder {
     // And for the more magical stuff
     function getJoins() {
 
+    }
+
+    function getModelMeta() {
+        return $this->meta;
     }
 }

--- a/tests/Northwind/Models.php
+++ b/tests/Northwind/Models.php
@@ -11,9 +11,6 @@ extends Model\ModelBase {
         'table' => 'Products',
         'pk' => ['ProductID'],
         'joins' => [
-            'supplier' => [
-                'constraint' => ['SupplierID' => 'Supplier.SupplierID'],
-            ],
             'category' => [
                 'constraint' => ['CategoryID' => 'Category.CategoryID'],
             ],
@@ -27,7 +24,10 @@ extends Model\ModelBase {
         $b->addFields([
             'ProductID'     => new Fields\AutoIdField(['pk' => true]),
             'ProductName'   => new Fields\TextField(['length' => 40]),
-            'SupplierID'    => new Fields\ForeignKey(Supplier::class, ['join' => 'supplier']),
+            'SupplierID'    => new Fields\ForeignKey(Supplier::class, [
+                'join' => 'supplier',
+                'reverse_name' => 'products',
+            ]),
             'CategoryID'    => new Fields\IntegerField(),
             'QuantityPerUnit' => new Fields\TextField(['length' => 20]),
             'UnitPrice'     => new Fields\DecimalField(),
@@ -54,11 +54,6 @@ extends Model\ModelBase {
     static $meta = [
         'table' => 'Suppliers',
         'pk' => ['SupplierID'],
-        'joins' => [
-            'products' => [
-                'reverse' => 'Product.supplier',
-            ],
-        ],
     ];
 
     static function buildSchema(SchemaBuilder $b) {
@@ -118,9 +113,6 @@ extends Model\ModelBase {
         'table' => 'Orders',
         'pk' => ['OrderID'],
         'joins' => [
-            'customer' => [
-                'constraint' => ['CustomerID' => 'Customer.CustomerID'],
-            ],
             'employee' => [
                 'constraint' => ['EmployeeID' => 'Employee.EmployeeID'],
             ],
@@ -139,7 +131,10 @@ extends Model\ModelBase {
     static function buildSchema(SchemaBuilder $b) {
         $b->addFields([
             'OrderID'       => new Fields\AutoIdField(['pk' => true]),
-            'CustomerID'    => new Fields\ForeignKey(Customer::class, ['join'=>'orders']),
+            'CustomerID'    => new Fields\ForeignKey(Customer::class, [
+                'join' => 'customer',
+                'reverse_name' => 'orders'
+            ]),
             'EmployeeID'    => new Fields\IntegerField(),
             'OrderDate'     => new Fields\DatetimeField(),
             'RequiredDate'  => new Fields\DatetimeField(),
@@ -317,11 +312,6 @@ extends Model\ModelBase {
     static $meta = [
         'table' => 'Customers',
         'pk' => ['CustomerID'],
-        'joins' => [
-            'orders' => [
-                'reverse' => 'Order.customer',
-            ],
-        ],
         'edges' => [
             'demographics' => [
                 'target' => Demographic::class,


### PR DESCRIPTION
A model does not need to specify both `joins` in the static meta data and ForeignKey fields. Instead, it can specify the join name and the reverse join name (`reverse_name`) in the options for a ForeignKey field. When inspected, the ForeignKey will add the joins to the local and foreign models automatically.

ForeignKey now extends from BaseField, but delegates the database interactions to the referenced field type. This will allow for proper type conversion of data types for queries involving ForeignKey fields without repeating the foreign key column. That is, the ForeignKey field will emulate the field which it references.

### Outstanding
  * [x] Add delegation for Transform lookup, so for instance, a ForeignKey to a TextField could use the text transforms