### PR TITLE
Many to many relationships

### DIFF
--- a/src/Db/Compile/SqlCompiler.php
+++ b/src/Db/Compile/SqlCompiler.php
@@ -182,7 +182,16 @@ abstract class SqlCompiler {
 
             // Roll to foreign model
             list($model, $tail) = $info['fkey'];
-            array_shift($path);
+
+            // If the path at this point is a many-to-many relation, then the
+            // `through` component needs to be added and the foreign model will
+            // become the `target` of the relation
+            if (isset($info['through'])) {
+                list($path[0],) = $info['through'];
+            }
+            else {
+                array_shift($path);
+            }
         }
         // There are two reasons to arrive here:
         // (1) the next item in the path does not represent a join. In this

--- a/src/Db/Model/ModelMeta.php
+++ b/src/Db/Model/ModelMeta.php
@@ -288,20 +288,19 @@ implements \ArrayAccess {
             if (!class_exists($edge['through']))
                 throw new Exception\ModelConfigurationError(sprintf(
                     '%s: Intermediate model for edge does not exist', $edge['through']));
-            
-            // For this configuration, the `through` model is inspected for
-            // a relationship to reverse
+
+            // Identify the middle model fkey (through) and the target model
+            // fkey (target)
             foreach ($edge['through']::getMeta('joins') as $field=>$info) {
                 list($class, $pk) = $info['fkey'];
                 if ($class === $this->model) {
-                    $join['reverse'] = sprintf("%s.%s", $edge['through'], $field);
+                    $join['reverse'] = [$edge['through'], $field];
                     break;
                 }
             }
-            
-            // The join information should have a `through` field which has 
-            // the intermediate model and the relation between it and the 
-            // target model.
+
+            // For this configuration, the `through` model is inspected for
+            // a relationship to reverse
             foreach ($edge['through']::getMeta('joins') as $field=>$info) {
                 list($class, $pk) = $info['fkey'];
                 if ($class === $edge['target']) {

--- a/tests/EdgeRelationTest.php
+++ b/tests/EdgeRelationTest.php
@@ -50,4 +50,11 @@ extends \PHPUnit_Framework_TestCase {
         $this->assertEquals($item->getQuantityShippable(), 13);
         $this->assertFalse($item->shouldReorder());
     }
+
+    function testFilterAcrossEdge() {
+        # Number of orders requiring a backorder slip (if filled today)
+        $this->assertCount(160,
+            Northwind\Order::objects()->filter(['details__UnitsInStock' => 0])
+        );
+    }
 }

--- a/tests/Northwind/Models.php
+++ b/tests/Northwind/Models.php
@@ -91,7 +91,10 @@ extends Model\ModelBase {
 
     static function buildSchema(SchemaBuilder $b) {
         $b->addFields([
-            'OrderID'       => new Fields\IntegerField(),
+            'OrderID'       => new Fields\ForeignKey(Order::class, [
+                'reverse_name' => 'items',
+                'join' => 'order',
+            ]),
             'ProductID'     => new Fields\IntegerField(),
             'UnitPrice'     => new Fields\DecimalField(),
             'Quantity'      => new Fields\IntegerField(),
@@ -121,7 +124,7 @@ extends Model\ModelBase {
             ],
         ],
         'edges' => [
-            'items' => [
+            'details' => [
                 'target' => Product::class,
                 'through' => OrderDetail::class
             ]

--- a/tests/QuerySetTest.php
+++ b/tests/QuerySetTest.php
@@ -101,13 +101,13 @@ extends \PHPUnit_Framework_TestCase {
     function testExists() {
         // Anyone handling Seattle?
         $seattle = Northwind\Employee::objects()
-            ->filter(['territories__territory__TerritoryDescription' => 'Seattle']);
+            ->filter(['territories__TerritoryDescription' => 'Seattle']);
 
         // Looks like there is
         $this->assertTrue($seattle->exists());
 
         $seattle = Northwind\Employee::objects()
-            ->filter(['territories__territory__TerritoryDescription' => 'Podunk']);
+            ->filter(['territories__TerritoryDescription' => 'Podunk']);
         // and a fetch
         $this->assertFalse($seattle->exists(true));
     }
@@ -115,7 +115,7 @@ extends \PHPUnit_Framework_TestCase {
     function testLeftJoinPropagation() {
         $total = count(Northwind\Employee::objects());
         $handled = Northwind\Employee::objects()
-            ->annotate(['territory_count' => Util\Aggregate::COUNT('territories__territory__region')]);
+            ->annotate(['territory_count' => Util\Aggregate::COUNT('territories__region')]);
 
         // The regex searches for LEFT JOIN followed by JOIN not preceeded by LEFT
         $this->assertNotRegexp('/LEFT JOIN .+? ((?<!LEFT )JOIN)/', (string) $handled,


### PR DESCRIPTION
This starts the conversation of changing the handling of many-to-many relationships. With this patch, the middle model is bypassed in filter expressions. This is a good thing in that it matches closer to the way most people approach m2m relationships; however, in order to filter based on- or aggregate fields in the middle model, a second join is required -- either explicitly or from the `reverse_name` of the ForeignKey in the middle model.

### Outstanding
  * [ ] Add option to bypass middle model (default TRUE)?
  * [ ] Add option to overlay middle model with InstrumentedEdges (default TRUE)?